### PR TITLE
Reduce dependencies

### DIFF
--- a/proxied.cabal
+++ b/proxied.cabal
@@ -56,8 +56,10 @@ library
   if impl(ghc >= 8.0)
     exposed-modules:   Data.Proxyless
   build-depends:       base             >= 4.3    && < 5
-                     , generic-deriving >= 1.10.1 && < 2
-                     , tagged           >= 0.4.4  && < 1
+  if impl(ghc < 7.6)
+    build-depends:     generic-deriving >= 1.10.1 && < 2
+  if impl(ghc < 7.8)
+    build-depends:     tagged           >= 0.4.4  && < 1
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/src/Data/Proxied.hs
+++ b/src/Data/Proxied.hs
@@ -81,8 +81,12 @@ import Data.Proxy
 
 import Foreign.Storable (Storable(..))
 
+#if MIN_VERSION_base(4,6,0)
+import GHC.Generics
+#else
 import Generics.Deriving.Base
 import Generics.Deriving.Instances ()
+#endif
 
 #if MIN_VERSION_base(4,7,0)
 import Data.Bits (FiniteBits(..))


### PR DESCRIPTION
Removes unnecessary dependencies for GHC 7.6 and 7.8 which include GHC.Generics and Data.Proxy respectively.